### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "brightoak/envoyer",
     "description": "A command to invoke a deployment via envoyer using the DEPLOY_URL environment variable",
+    "type": "wp-cli-package",
     "homepage": "https://github.com/brightoak/envoyer",
     "authors": [],
     "minimum-stability": "dev",


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
